### PR TITLE
Prevent loading of css at nav_root_url

### DIFF
--- a/Products/CMFPlone/patterns/tinymce.py
+++ b/Products/CMFPlone/patterns/tinymce.py
@@ -49,7 +49,7 @@ class TinyMCESettingsGenerator(object):
                 files.append('/'.join([self.nav_root_url, url.strip()]))
         theme = self.get_theme()
         tinymce_content_css = getattr(theme, 'tinymce_content_css', None)
-        if tinymce_content_css is not None:
+        if tinymce_content_css is not None and tinymce_content_css != '':
             for path in theme.tinymce_content_css.split(','):
                 if path.startswith('http://') or path.startswith('https://'):
                     files.append(path)


### PR DESCRIPTION
If 'tinymce-content-css' option is missing in themes manifest.cfg its default value is `''`. If we check only for `None` here an unnecessary request to nav root is triggered.

I found that while improving performance. It looked like that:
![unnecessary_css](https://user-images.githubusercontent.com/5301889/57620704-db328000-7589-11e9-9d5d-e7ce333eed17.jpg)

